### PR TITLE
Remove Mozilla JS namespace from library (Fixes #4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# HEAD
+
+## Bug Fixes
+* **js:** Remove `Mozilla` JS namespace from library (#4).

--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@
 
 (If you want to skip the spiel and get straight to business, check out the [docs](./documentation.md).)
 
+### How to install and use
+
+Install via npm: `npm install @mozmeao/trafficcop`
+
+Import the library at your applications entrypoint via require, import or by using a global variable in your script tag:
+
+-   `import TrafficCop from '@mozmeao/trafficcop';`
+-   `const TrafficCop= require('@mozmeao/trafficcop')`
+-   `const TrafficCop = window.TrafficCop;`
+
 ### What does it do?
 
 Traffic Cop is a small bit of JavaScript that decides if a visitor should participate in a variation of the current page. If so, a cookie is set and one of two things happens:
@@ -42,7 +52,7 @@ Implementing Traffic Cop requires at least two other JavaScript files: one to co
 
 ```javascript
 // example configuration for a redirect experiment
-var wiggum = new Mozilla.TrafficCop({
+var wiggum = new TrafficCop({
   id: ‘experiment-promo-fall-2017’,
   variations: {
     ‘v=1’: 10.5,
@@ -64,7 +74,7 @@ function myCallback(variation) {
     // and then change button color based on variation chosen...
 }
 
-var lou = new Mozilla.TrafficCop({
+var lou = new TrafficCop({
   id: ‘experiment-button-color’,
   customCallback: myCallback,
   variations: {

--- a/demo/src/public/experiment-page1.js
+++ b/demo/src/public/experiment-page1.js
@@ -1,7 +1,7 @@
 (function () {
     'use strict';
 
-    var eddie = new Mozilla.TrafficCop({
+    var eddie = new window.TrafficCop({
         id: 'experiment-page-1',
         cookieExpires: 0, // session length cookie
         variations: {

--- a/demo/src/public/experiment-page2.js
+++ b/demo/src/public/experiment-page2.js
@@ -27,7 +27,7 @@
             : document.addEventListener('DOMContentLoaded', callback);
     }
 
-    var wiggum = new Mozilla.TrafficCop({
+    var wiggum = new window.TrafficCop({
         id: 'experiment-page-2',
         customCallback: handleVariation,
         variations: variants

--- a/demo/src/public/experiment-page3-customcallback.js
+++ b/demo/src/public/experiment-page3-customcallback.js
@@ -13,7 +13,7 @@
         }
     }
 
-    var wiggum = new Mozilla.TrafficCop({
+    var wiggum = new window.TrafficCop({
         id: 'experiment-page-3-customcallback',
         customCallback: handleVariation,
         variations: variants

--- a/demo/src/public/experiment-page3-redirect.js
+++ b/demo/src/public/experiment-page3-redirect.js
@@ -1,7 +1,7 @@
 (function () {
     'use strict';
 
-    var lou = new Mozilla.TrafficCop({
+    var lou = new window.TrafficCop({
         id: 'experiment-page-3',
         storeReferrerCookie: false, // don't store original referrer on redirect
         variations: {

--- a/documentation.md
+++ b/documentation.md
@@ -26,7 +26,7 @@ function myCallback(variation) {
     // and then change button color based on variation chosen...
 }
 
-var lou = new Mozilla.TrafficCop({
+var lou = new TrafficCop({
   id: ‘experiment-button-color’,
   customCallback: myCallback,
   variations: {
@@ -54,7 +54,7 @@ Any query string parameters present when a user initially lands on a page will b
 
 ```javascript
 // example configuration for a redirect experiment
-var wiggum = new Mozilla.TrafficCop({
+var wiggum = new TrafficCop({
   id: ‘experiment-promo-fall-2017’,
   variations: {
     ‘v=1’: 0.15,
@@ -82,7 +82,7 @@ Check out the demo for a live example of this setup.
 Variations are sorted in the order provided, and percentages are tallied to create tiers. Take the following config:
 
 ```javascript
-var rex = new Mozilla.TrafficCop({
+var rex = new TrafficCop({
     id: 'experiment-new-headline',
     variations: {
         'v=a': 15,
@@ -111,7 +111,7 @@ Each instance of a Traffic Cop requires at least two pieces of configuration:
 An implementation for a redirect experiment might look like:
 
 ```javascript
-var eddie = new Mozilla.TrafficCop({
+var eddie = new TrafficCop({
     id: 'experiment-new-headline',
     variations: {
         'v=1': 12.2,
@@ -136,7 +136,7 @@ To specify how long the cookie associated with a visitor for an individual exper
 An implementation with `cookieExpires` set might look like the following:
 
 ```javascript
-var lou = new Mozilla.TrafficCop({
+var lou = new TrafficCop({
     id: 'experiment-homepage-spring-2017',
     customCallback: someCallbackFunction,
     cookieExpires: 0, // lasts until user closes the window/tab

--- a/src/mozilla-traffic-cop.js
+++ b/src/mozilla-traffic-cop.js
@@ -2,17 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-// create namespace
-if (typeof window.Mozilla === 'undefined') {
-    window.Mozilla = {};
-}
-
 /**
  * Traffic Cop traffic redirector for A/B/x testing
  *
  * Example usage:
  *
- * var cop = new Mozilla.TrafficCop({
+ * var cop = new TrafficCop({
  *     id: 'exp_firefox_new_all_link',
  *     cookieExpires: 48,
  *     variations: {
@@ -48,7 +43,7 @@ if (typeof window.Mozilla === 'undefined') {
  *              'v=3': 20
  *          }
  */
-Mozilla.TrafficCop = function (config) {
+const TrafficCop = function (config) {
     'use strict';
 
     // make sure config is an object
@@ -73,9 +68,9 @@ Mozilla.TrafficCop = function (config) {
     this.cookieExpires =
         this.config.cookieExpires !== undefined
             ? this.config.cookieExpires
-            : Mozilla.TrafficCop.defaultCookieExpires;
+            : TrafficCop.defaultCookieExpires;
 
-    this.cookieExpiresDate = Mozilla.TrafficCop.generateCookieExpiresDate(
+    this.cookieExpiresDate = TrafficCop.generateCookieExpiresDate(
         this.cookieExpires
     );
 
@@ -102,15 +97,15 @@ Mozilla.TrafficCop = function (config) {
     return this;
 };
 
-Mozilla.TrafficCop.defaultCookieExpires = 24;
-Mozilla.TrafficCop.noVariationCookieValue = 'novariation';
-Mozilla.TrafficCop.referrerCookieName = 'mozilla-traffic-cop-original-referrer';
+TrafficCop.defaultCookieExpires = 24;
+TrafficCop.noVariationCookieValue = 'novariation';
+TrafficCop.referrerCookieName = 'mozilla-traffic-cop-original-referrer';
 
 /*
  * Initialize the traffic cop. Validates variations, ensures user is not
  * currently viewing a variation, and (possibly) redirects to a variation
  */
-Mozilla.TrafficCop.prototype.init = function () {
+TrafficCop.prototype.init = function () {
     // respect the DNT
     if (typeof Mozilla.dntEnabled === 'function' && Mozilla.dntEnabled()) {
         return;
@@ -124,7 +119,7 @@ Mozilla.TrafficCop.prototype.init = function () {
     // make sure config is valid (id & variations present)
     if (this.verifyConfig()) {
         // determine which (if any) variation to choose for this user/experiment
-        this.chosenVariation = Mozilla.TrafficCop.chooseVariation(
+        this.chosenVariation = TrafficCop.chooseVariation(
             this.id,
             this.variations,
             this.totalPercentage
@@ -144,11 +139,11 @@ Mozilla.TrafficCop.prototype.init = function () {
  * Executes the logic around firing the custom callback specified by the
  * developer.
  */
-Mozilla.TrafficCop.prototype.initiateCustomCallbackRoutine = function () {
+TrafficCop.prototype.initiateCustomCallbackRoutine = function () {
     // set a cookie to remember the chosen variation
     Mozilla.Cookies.setItem(
         this.id,
-        this.chosenVariation || Mozilla.TrafficCop.noVariationCookieValue,
+        this.chosenVariation || TrafficCop.noVariationCookieValue,
         this.cookieExpiresDate,
         undefined,
         undefined,
@@ -164,16 +159,14 @@ Mozilla.TrafficCop.prototype.initiateCustomCallbackRoutine = function () {
  * Executes logic around determining variation to which the visitor will be
  * redirected. May result in no redirect.
  */
-Mozilla.TrafficCop.prototype.initiateRedirectRoutine = function () {
+TrafficCop.prototype.initiateRedirectRoutine = function () {
     var redirectUrl;
 
     // make sure current page doesn't match a variation
     // (avoid infinite redirects)
-    if (!Mozilla.TrafficCop.isRedirectVariation(this.variations)) {
+    if (!TrafficCop.isRedirectVariation(this.variations)) {
         // roll the dice to see if user should be send to a variation
-        redirectUrl = Mozilla.TrafficCop.generateRedirectUrl(
-            this.chosenVariation
-        );
+        redirectUrl = TrafficCop.generateRedirectUrl(this.chosenVariation);
 
         // if we get a variation, send the user and store a cookie
         if (redirectUrl) {
@@ -183,10 +176,10 @@ Mozilla.TrafficCop.prototype.initiateRedirectRoutine = function () {
             // Traffic Cop does nothing with this referrer - it's up to the implementing site to
             // send it on to an analytics platform (or whatever).
             if (this.storeReferrerCookie) {
-                Mozilla.TrafficCop.setReferrerCookie(this.cookieExpiresDate);
+                TrafficCop.setReferrerCookie(this.cookieExpiresDate);
                 // a previous experiment may have set the cookie, so explicitly remove it here
             } else {
-                Mozilla.TrafficCop.clearReferrerCookie();
+                TrafficCop.clearReferrerCookie();
             }
 
             // set a cookie containing the chosen variation
@@ -200,13 +193,13 @@ Mozilla.TrafficCop.prototype.initiateRedirectRoutine = function () {
                 'lax'
             );
 
-            Mozilla.TrafficCop.performRedirect(redirectUrl);
+            TrafficCop.performRedirect(redirectUrl);
         } else {
             // if no variation, set a cookie so user isn't re-entered into
             // the dice roll on next page load
             Mozilla.Cookies.setItem(
                 this.id,
-                Mozilla.TrafficCop.noVariationCookieValue,
+                TrafficCop.noVariationCookieValue,
                 this.cookieExpiresDate,
                 undefined,
                 undefined,
@@ -215,7 +208,7 @@ Mozilla.TrafficCop.prototype.initiateRedirectRoutine = function () {
             );
 
             // same as above - referrer cookie could be set from previous experiment, so best to clear
-            Mozilla.TrafficCop.clearReferrerCookie();
+            TrafficCop.clearReferrerCookie();
         }
     }
 };
@@ -224,7 +217,7 @@ Mozilla.TrafficCop.prototype.initiateRedirectRoutine = function () {
  * Ensures variations were provided and in total capture between 1 and 99%
  * of users.
  */
-Mozilla.TrafficCop.prototype.verifyConfig = function () {
+TrafficCop.prototype.verifyConfig = function () {
     if (!this.id || typeof this.id !== 'string') {
         return false;
     }
@@ -246,7 +239,7 @@ Mozilla.TrafficCop.prototype.verifyConfig = function () {
  * Generates an expiration date for the visitor's cookie.
  * 'date' param used only for unit testing.
  */
-Mozilla.TrafficCop.generateCookieExpiresDate = function (cookieExpires, date) {
+TrafficCop.generateCookieExpiresDate = function (cookieExpires, date) {
     // default to null, meaning a session-length cookie
     var d = null;
 
@@ -261,7 +254,7 @@ Mozilla.TrafficCop.generateCookieExpiresDate = function (cookieExpires, date) {
 /*
  * Checks to see if user is currently viewing a variation.
  */
-Mozilla.TrafficCop.isRedirectVariation = function (variations, queryString) {
+TrafficCop.isRedirectVariation = function (variations, queryString) {
     var isVariation = false;
     queryString = queryString || window.location.search;
 
@@ -282,22 +275,17 @@ Mozilla.TrafficCop.isRedirectVariation = function (variations, queryString) {
 /*
  * Returns the variation chosen for the current user/experiment.
  */
-Mozilla.TrafficCop.chooseVariation = function (
-    id,
-    variations,
-    totalPercentage
-) {
+TrafficCop.chooseVariation = function (id, variations, totalPercentage) {
     var rando;
     var runningTotal;
-    var choice = Mozilla.TrafficCop.noVariationCookieValue;
+    var choice = TrafficCop.noVariationCookieValue;
 
     // check to see if user has a cookie from a previously visited variation
     // also make sure variation in cookie is still valid (you never know)
     if (
         Mozilla.Cookies.hasItem(id) &&
         (variations[Mozilla.Cookies.getItem(id)] ||
-            Mozilla.Cookies.getItem(id) ===
-                Mozilla.TrafficCop.noVariationCookieValue)
+            Mozilla.Cookies.getItem(id) === TrafficCop.noVariationCookieValue)
     ) {
         choice = Mozilla.Cookies.getItem(id);
         // no cookie exists, or cookie has invalid variation, so choose a shiny new
@@ -333,7 +321,7 @@ Mozilla.TrafficCop.chooseVariation = function (
  * Generates a random percentage (between 1 and 100, inclusive) and determines
  * which (if any) variation should be matched.
  */
-Mozilla.TrafficCop.generateRedirectUrl = function (chosenVariation, url) {
+TrafficCop.generateRedirectUrl = function (chosenVariation, url) {
     var hash;
     var redirect;
     var urlParts;
@@ -349,7 +337,7 @@ Mozilla.TrafficCop.generateRedirectUrl = function (chosenVariation, url) {
     }
 
     // if a variation was chosen, construct a new URL
-    if (chosenVariation !== Mozilla.TrafficCop.noVariationCookieValue) {
+    if (chosenVariation !== TrafficCop.noVariationCookieValue) {
         redirect = url + (url.indexOf('?') > -1 ? '&' : '?') + chosenVariation;
 
         // re-insert hash (if originally present)
@@ -361,19 +349,19 @@ Mozilla.TrafficCop.generateRedirectUrl = function (chosenVariation, url) {
     return redirect;
 };
 
-Mozilla.TrafficCop.performRedirect = function (redirectURL) {
+TrafficCop.performRedirect = function (redirectURL) {
     window.location.href = redirectURL;
 };
 
-Mozilla.TrafficCop.setReferrerCookie = function (expirationDate, referrer) {
+TrafficCop.setReferrerCookie = function (expirationDate, referrer) {
     // in order of precedence, referrer should be:
     // 1. custom value passed in via unit test
     // 2. value of document.referrer
     // 3. 'direct' string literal
-    referrer = referrer || Mozilla.TrafficCop.getDocumentReferrer() || 'direct';
+    referrer = referrer || TrafficCop.getDocumentReferrer() || 'direct';
 
     Mozilla.Cookies.setItem(
-        Mozilla.TrafficCop.referrerCookieName,
+        TrafficCop.referrerCookieName,
         referrer,
         expirationDate,
         undefined,
@@ -383,11 +371,13 @@ Mozilla.TrafficCop.setReferrerCookie = function (expirationDate, referrer) {
     );
 };
 
-Mozilla.TrafficCop.clearReferrerCookie = function () {
-    Mozilla.Cookies.removeItem(Mozilla.TrafficCop.referrerCookieName);
+TrafficCop.clearReferrerCookie = function () {
+    Mozilla.Cookies.removeItem(TrafficCop.referrerCookieName);
 };
 
 // wrapper around document.referrer for better unit testing
-Mozilla.TrafficCop.getDocumentReferrer = function () {
+TrafficCop.getDocumentReferrer = function () {
     return document.referrer;
 };
+
+module.exports = TrafficCop;

--- a/tests/test-traffic-cop.js
+++ b/tests/test-traffic-cop.js
@@ -18,73 +18,73 @@ describe('mozilla-traffic-cop.js', function () {
         window.Mozilla.Cookies.hasItem = sinon.stub().returns(false);
 
         // actual redirect shouldn't happen in tests
-        Mozilla.TrafficCop.performRedirect = sinon.stub();
+        window.TrafficCop.performRedirect = sinon.stub();
     });
 
-    describe('Mozilla.TrafficCop instantiation defaults', function () {
+    describe('TrafficCop instantiation defaults', function () {
         it('should store supplied config', function () {
-            var config = {
+            const config = {
                 id: 'testABC'
             };
-            var cop = new Mozilla.TrafficCop(config);
+            const cop = new window.TrafficCop(config);
             expect(cop.config).toEqual(config);
         });
 
         it('should default to an empty object if supplied config is not an object', function () {
-            var config = 'purplemonkeydishwasher';
+            const config = 'purplemonkeydishwasher';
 
-            var cop = new Mozilla.TrafficCop(config);
+            const cop = new window.TrafficCop(config);
             expect(cop.config).toEqual({});
         });
 
         it('should store supplied customCallback', function () {
-            var funkyFunc = sinon.stub();
-            var cop = new Mozilla.TrafficCop({
+            const funkyFunc = sinon.stub();
+            const cop = new window.TrafficCop({
                 customCallback: funkyFunc
             });
             expect(cop.customCallback).toEqual(funkyFunc);
         });
 
         it('should default customCallback to null if not supplied', function () {
-            var cop = new Mozilla.TrafficCop();
+            const cop = new window.TrafficCop();
             expect(cop.customCallback).toEqual(null);
         });
 
         it('should set customCallback to null if not supplied with a function', function () {
-            var cop = new Mozilla.TrafficCop({
+            const cop = new window.TrafficCop({
                 customCallback: 'frinkahedron'
             });
             expect(cop.customCallback).toEqual(null);
         });
 
         it('should store cookieExpires if specified', function () {
-            var cop = new Mozilla.TrafficCop({
+            const cop = new window.TrafficCop({
                 cookieExpires: 48
             });
             expect(cop.cookieExpires).toEqual(48);
         });
 
         it('should default cookieExpires to 24 if not specified', function () {
-            var cop = new Mozilla.TrafficCop();
+            const cop = new window.TrafficCop();
             expect(cop.cookieExpires).toEqual(
-                Mozilla.TrafficCop.defaultCookieExpires
+                window.TrafficCop.defaultCookieExpires
             );
         });
 
         it('should store storeReferrerCookie if specified', function () {
-            var cop = new Mozilla.TrafficCop({
+            const cop = new window.TrafficCop({
                 storeReferrerCookie: false
             });
             expect(cop.storeReferrerCookie).toEqual(false);
         });
 
         it('should default storeReferrerCookie to true if not specified', function () {
-            var cop = new Mozilla.TrafficCop();
+            const cop = new window.TrafficCop();
             expect(cop.storeReferrerCookie).toEqual(true);
         });
 
         it('should calculate totalPercentage based off supplied variations', function () {
-            var cop = new Mozilla.TrafficCop({
+            const cop = new window.TrafficCop({
                 variations: {
                     'v=1': 25,
                     'v=2': 15,
@@ -95,7 +95,7 @@ describe('mozilla-traffic-cop.js', function () {
         });
 
         it('should handle variation percentages in the tenths', function () {
-            var cop = new Mozilla.TrafficCop({
+            const cop = new window.TrafficCop({
                 variations: {
                     'v=1': 10.4,
                     'v=2': 0.2,
@@ -107,7 +107,7 @@ describe('mozilla-traffic-cop.js', function () {
         });
 
         it('should handle variation percentages in the hundredths', function () {
-            var cop = new Mozilla.TrafficCop({
+            const cop = new window.TrafficCop({
                 variations: {
                     'v=1': 9.04,
                     'v=2': 10.25,
@@ -119,8 +119,8 @@ describe('mozilla-traffic-cop.js', function () {
         });
     });
 
-    describe('Mozilla.TrafficCop.init', function () {
-        var cop = new Mozilla.TrafficCop({
+    describe('TrafficCop.init', function () {
+        const cop = new window.TrafficCop({
             id: 'test123',
             variations: {
                 'v=1': 20,
@@ -145,7 +145,7 @@ describe('mozilla-traffic-cop.js', function () {
         });
 
         it('should initialize if DNT helper function is not available', function () {
-            var dntBak = Mozilla.dntEnabled;
+            const dntBak = Mozilla.dntEnabled;
             Mozilla.dntEnabled = undefined;
             cop.init();
             expect(cop.verifyConfig).toHaveBeenCalled();
@@ -159,12 +159,12 @@ describe('mozilla-traffic-cop.js', function () {
         });
     });
 
-    describe('Mozilla.TrafficCop.init redirect', function () {
+    describe('TrafficCop.init redirect', function () {
         afterEach(function () {
             cop.storeReferrerCookie = true;
         });
 
-        var cop = new Mozilla.TrafficCop({
+        const cop = new window.TrafficCop({
             id: 'test123',
             variations: {
                 'v=1': 20,
@@ -173,43 +173,39 @@ describe('mozilla-traffic-cop.js', function () {
         });
 
         it('should call setReferrerCookie by default', function () {
-            spyOn(Mozilla.TrafficCop, 'isRedirectVariation').and.returnValue(
+            spyOn(window.TrafficCop, 'isRedirectVariation').and.returnValue(
                 false
             );
-            spyOn(Mozilla.TrafficCop, 'generateRedirectUrl').and.returnValue(
+            spyOn(window.TrafficCop, 'generateRedirectUrl').and.returnValue(
                 'http://www.mozilla.com/en-US/?v=1'
             );
-            spyOn(Mozilla.TrafficCop, 'setReferrerCookie').and.returnValue(
-                true
-            );
+            spyOn(window.TrafficCop, 'setReferrerCookie').and.returnValue(true);
 
             cop.init();
 
-            expect(Mozilla.TrafficCop.setReferrerCookie).toHaveBeenCalled();
+            expect(window.TrafficCop.setReferrerCookie).toHaveBeenCalled();
         });
 
         it('should not call setReferrerCookie when specified in config', function () {
             cop.storeReferrerCookie = false;
 
-            spyOn(Mozilla.TrafficCop, 'isRedirectVariation').and.returnValue(
+            spyOn(window.TrafficCop, 'isRedirectVariation').and.returnValue(
                 false
             );
-            spyOn(Mozilla.TrafficCop, 'generateRedirectUrl').and.returnValue(
+            spyOn(window.TrafficCop, 'generateRedirectUrl').and.returnValue(
                 'http://www.mozilla.com/en-US/?v=1'
             );
-            spyOn(Mozilla.TrafficCop, 'setReferrerCookie').and.returnValue(
-                true
-            );
+            spyOn(window.TrafficCop, 'setReferrerCookie').and.returnValue(true);
 
             cop.init();
 
-            expect(Mozilla.TrafficCop.setReferrerCookie).not.toHaveBeenCalled();
+            expect(window.TrafficCop.setReferrerCookie).not.toHaveBeenCalled();
         });
     });
 
-    describe('Mozilla.TrafficCop.init customCallback', function () {
+    describe('TrafficCop.init customCallback', function () {
         it('should call customCallback when specified', function () {
-            var cop = new Mozilla.TrafficCop({
+            const cop = new window.TrafficCop({
                 id: 'test123',
                 customCallback: sinon.stub(),
                 variations: {
@@ -218,7 +214,7 @@ describe('mozilla-traffic-cop.js', function () {
                 }
             });
 
-            spyOn(Mozilla.TrafficCop, 'chooseVariation').and.returnValue('a');
+            spyOn(window.TrafficCop, 'chooseVariation').and.returnValue('a');
             spyOn(cop, 'customCallback');
 
             cop.init();
@@ -227,7 +223,7 @@ describe('mozilla-traffic-cop.js', function () {
         });
 
         it('should not attempt a redirect if customCallback is specified', function () {
-            var cop = new Mozilla.TrafficCop({
+            const cop = new window.TrafficCop({
                 id: 'test123',
                 customCallback: sinon.stub(),
                 variations: {
@@ -236,21 +232,21 @@ describe('mozilla-traffic-cop.js', function () {
                 }
             });
 
-            spyOn(Mozilla.TrafficCop, 'generateRedirectUrl');
-            spyOn(Mozilla.TrafficCop, 'performRedirect');
+            spyOn(window.TrafficCop, 'generateRedirectUrl');
+            spyOn(window.TrafficCop, 'performRedirect');
 
             cop.init();
 
             expect(
-                Mozilla.TrafficCop.generateRedirectUrl
+                window.TrafficCop.generateRedirectUrl
             ).not.toHaveBeenCalled();
-            expect(Mozilla.TrafficCop.performRedirect).not.toHaveBeenCalled();
+            expect(window.TrafficCop.performRedirect).not.toHaveBeenCalled();
         });
     });
 
-    describe('Mozilla.TrafficCop.verifyConfig', function () {
+    describe('TrafficCop.verifyConfig', function () {
         it('should return true for valid id and variations', function () {
-            var cop = new Mozilla.TrafficCop({
+            const cop = new window.TrafficCop({
                 id: 'test123',
                 variations: {
                     'v=1': 20,
@@ -262,13 +258,13 @@ describe('mozilla-traffic-cop.js', function () {
         });
 
         it('should return false when no id or variations are provided', function () {
-            var cop = new Mozilla.TrafficCop();
+            const cop = new window.TrafficCop();
 
             expect(cop.verifyConfig()).toBeFalsy();
         });
 
         it('should return false when no id is provided', function () {
-            var cop = new Mozilla.TrafficCop({
+            const cop = new window.TrafficCop({
                 variations: {
                     'v=1': 80
                 }
@@ -278,7 +274,7 @@ describe('mozilla-traffic-cop.js', function () {
         });
 
         it('should return false when no variations provided', function () {
-            var cop = new Mozilla.TrafficCop({
+            const cop = new window.TrafficCop({
                 id: 'test123',
                 variations: {}
             });
@@ -287,7 +283,7 @@ describe('mozilla-traffic-cop.js', function () {
         });
 
         it('should return false when variation percentage is 0', function () {
-            var cop = new Mozilla.TrafficCop({
+            const cop = new window.TrafficCop({
                 id: 'test123',
                 variations: {
                     'v=1': 0,
@@ -299,7 +295,7 @@ describe('mozilla-traffic-cop.js', function () {
         });
 
         it('should return false when variation percentage exceeds 100', function () {
-            var cop = new Mozilla.TrafficCop({
+            const cop = new window.TrafficCop({
                 id: 'test123',
                 variations: {
                     'v=1': 50,
@@ -311,7 +307,7 @@ describe('mozilla-traffic-cop.js', function () {
         });
 
         it('should return true with a valid cookieExpires value', function () {
-            var cop = new Mozilla.TrafficCop({
+            const cop = new window.TrafficCop({
                 id: 'test123',
                 cookieExpires: 48,
                 variations: {
@@ -324,9 +320,9 @@ describe('mozilla-traffic-cop.js', function () {
         });
 
         it('should return false with an invalid cookieExpires value', function () {
-            var config1;
-            var config2;
-            var config3;
+            let config1;
+            let config2;
+            let config3;
 
             config1 =
                 config2 =
@@ -343,9 +339,9 @@ describe('mozilla-traffic-cop.js', function () {
             config2.cookieExpires = null;
             config3.cookieExpires = [];
 
-            var cop = new Mozilla.TrafficCop(config1);
-            var cop2 = new Mozilla.TrafficCop(config2);
-            var cop3 = new Mozilla.TrafficCop(config3);
+            const cop = new window.TrafficCop(config1);
+            const cop2 = new window.TrafficCop(config2);
+            const cop3 = new window.TrafficCop(config3);
 
             expect(cop.verifyConfig()).toBeFalsy();
             expect(cop2.verifyConfig()).toBeFalsy();
@@ -353,8 +349,8 @@ describe('mozilla-traffic-cop.js', function () {
         });
     });
 
-    describe('Mozilla.TrafficCop.generateCookieExpiresDate', function () {
-        var config = {
+    describe('TrafficCop.generateCookieExpiresDate', function () {
+        const config = {
             id: 'test123',
             variations: {
                 'v=1': 40,
@@ -364,8 +360,8 @@ describe('mozilla-traffic-cop.js', function () {
 
         it('should return a date 24 hours into the future when no hours are specified', function () {
             // a cop with no
-            var cop = new Mozilla.TrafficCop(config);
-            var expiry = Mozilla.TrafficCop.generateCookieExpiresDate(
+            const cop = new window.TrafficCop(config);
+            const expiry = window.TrafficCop.generateCookieExpiresDate(
                 cop.cookieExpires,
                 new Date(2017, 0, 1, 12, 30)
             );
@@ -375,7 +371,7 @@ describe('mozilla-traffic-cop.js', function () {
         });
 
         it('should return an appropriate future date when hours are specified', function () {
-            var expiry = Mozilla.TrafficCop.generateCookieExpiresDate(
+            const expiry = window.TrafficCop.generateCookieExpiresDate(
                 72,
                 new Date(2017, 0, 1, 12, 30)
             );
@@ -385,40 +381,40 @@ describe('mozilla-traffic-cop.js', function () {
         });
 
         it('should return null when 0 hours are specified', function () {
-            expect(Mozilla.TrafficCop.generateCookieExpiresDate(0)).toBe(null);
+            expect(window.TrafficCop.generateCookieExpiresDate(0)).toBe(null);
         });
     });
 
-    describe('Mozilla.TrafficCop.isRedirectVariation', function () {
-        var variations = {
+    describe('TrafficCop.isRedirectVariation', function () {
+        const variations = {
             'v=1': 40,
             'v=2': 30
         };
 
         it('should return false if the current queryString does not contain a variation', function () {
             expect(
-                Mozilla.TrafficCop.isRedirectVariation(variations, '?v=3')
+                window.TrafficCop.isRedirectVariation(variations, '?v=3')
             ).toBeFalsy();
             expect(
-                Mozilla.TrafficCop.isRedirectVariation(variations, '?fav=1')
+                window.TrafficCop.isRedirectVariation(variations, '?fav=1')
             ).toBeFalsy();
             expect(
-                Mozilla.TrafficCop.isRedirectVariation(variations, '?v=3&fav=1')
+                window.TrafficCop.isRedirectVariation(variations, '?v=3&fav=1')
             ).toBeFalsy();
         });
 
         it('should return true if the current querystring contains a variation', function () {
             expect(
-                Mozilla.TrafficCop.isRedirectVariation(variations, '?v=2')
+                window.TrafficCop.isRedirectVariation(variations, '?v=2')
             ).toBeTruthy();
             expect(
-                Mozilla.TrafficCop.isRedirectVariation(
+                window.TrafficCop.isRedirectVariation(
                     variations,
                     '?foo=bar&v=2'
                 )
             ).toBeTruthy();
             expect(
-                Mozilla.TrafficCop.isRedirectVariation(
+                window.TrafficCop.isRedirectVariation(
                     variations,
                     '?v=2&foo=bar'
                 )
@@ -426,8 +422,8 @@ describe('mozilla-traffic-cop.js', function () {
         });
     });
 
-    describe('Mozilla.TrafficCop.chooseVariation', function () {
-        var cop = new Mozilla.TrafficCop({
+    describe('TrafficCop.chooseVariation', function () {
+        const cop = new window.TrafficCop({
             id: 'test123',
             variations: {
                 'v=3': 30,
@@ -442,19 +438,19 @@ describe('mozilla-traffic-cop.js', function () {
             // random number >= 80 is greater than percentage total above (75.55)
             spyOn(window.Math, 'random').and.returnValue(0.7556);
             expect(
-                Mozilla.TrafficCop.chooseVariation(
+                window.TrafficCop.chooseVariation(
                     cop.id,
                     cop.variations,
                     cop.totalPercentage
                 )
-            ).toEqual(Mozilla.TrafficCop.noVariationCookieValue);
+            ).toEqual(window.TrafficCop.noVariationCookieValue);
         });
 
         it('should choose the first variation when random number is at the start of the range', function () {
             // first variation is 30%, so 1-30
             spyOn(window.Math, 'random').and.returnValue(0.01);
             expect(
-                Mozilla.TrafficCop.chooseVariation(
+                window.TrafficCop.chooseVariation(
                     cop.id,
                     cop.variations,
                     cop.totalPercentage
@@ -466,7 +462,7 @@ describe('mozilla-traffic-cop.js', function () {
             // first variation is 30%, so 1-30
             spyOn(window.Math, 'random').and.returnValue(0.29);
             expect(
-                Mozilla.TrafficCop.chooseVariation(
+                window.TrafficCop.chooseVariation(
                     cop.id,
                     cop.variations,
                     cop.totalPercentage
@@ -478,7 +474,7 @@ describe('mozilla-traffic-cop.js', function () {
             // second variation is 20%, so 31-50
             spyOn(window.Math, 'random').and.returnValue(0.3);
             expect(
-                Mozilla.TrafficCop.chooseVariation(
+                window.TrafficCop.chooseVariation(
                     cop.id,
                     cop.variations,
                     cop.totalPercentage
@@ -490,7 +486,7 @@ describe('mozilla-traffic-cop.js', function () {
             // second variation is 20%, so 31-50
             spyOn(window.Math, 'random').and.returnValue(0.49);
             expect(
-                Mozilla.TrafficCop.chooseVariation(
+                window.TrafficCop.chooseVariation(
                     cop.id,
                     cop.variations,
                     cop.totalPercentage
@@ -502,7 +498,7 @@ describe('mozilla-traffic-cop.js', function () {
             // third variation is 25.25%, so 51-75.25
             spyOn(window.Math, 'random').and.returnValue(0.5);
             expect(
-                Mozilla.TrafficCop.chooseVariation(
+                window.TrafficCop.chooseVariation(
                     cop.id,
                     cop.variations,
                     cop.totalPercentage
@@ -514,7 +510,7 @@ describe('mozilla-traffic-cop.js', function () {
             // third variation is 25.25%, so 51-75.25
             spyOn(window.Math, 'random').and.returnValue(0.7525);
             expect(
-                Mozilla.TrafficCop.chooseVariation(
+                window.TrafficCop.chooseVariation(
                     cop.id,
                     cop.variations,
                     cop.totalPercentage
@@ -526,7 +522,7 @@ describe('mozilla-traffic-cop.js', function () {
             // fourth variation is 0.2%, so 75.26-75.45
             spyOn(window.Math, 'random').and.returnValue(0.7526);
             expect(
-                Mozilla.TrafficCop.chooseVariation(
+                window.TrafficCop.chooseVariation(
                     cop.id,
                     cop.variations,
                     cop.totalPercentage
@@ -538,7 +534,7 @@ describe('mozilla-traffic-cop.js', function () {
             // fourth variation is 0.2%, so 75.26-75.45
             spyOn(window.Math, 'random').and.returnValue(0.7545);
             expect(
-                Mozilla.TrafficCop.chooseVariation(
+                window.TrafficCop.chooseVariation(
                     cop.id,
                     cop.variations,
                     cop.totalPercentage
@@ -550,7 +546,7 @@ describe('mozilla-traffic-cop.js', function () {
             // fifth variation is 0.1%, so 75.46
             spyOn(window.Math, 'random').and.returnValue(0.7546);
             expect(
-                Mozilla.TrafficCop.chooseVariation(
+                window.TrafficCop.chooseVariation(
                     cop.id,
                     cop.variations,
                     cop.totalPercentage
@@ -563,7 +559,7 @@ describe('mozilla-traffic-cop.js', function () {
             spyOn(Mozilla.Cookies, 'getItem').and.returnValue('v=2');
 
             expect(
-                Mozilla.TrafficCop.chooseVariation(
+                window.TrafficCop.chooseVariation(
                     cop.id,
                     cop.variations,
                     cop.totalPercentage
@@ -577,7 +573,7 @@ describe('mozilla-traffic-cop.js', function () {
             spyOn(window.Math, 'random').and.returnValue(0.74);
 
             expect(
-                Mozilla.TrafficCop.chooseVariation(
+                window.TrafficCop.chooseVariation(
                     cop.id,
                     cop.variations,
                     cop.totalPercentage
@@ -588,23 +584,23 @@ describe('mozilla-traffic-cop.js', function () {
         it('should choose noVariationCookieValue if user was placed into a no-variation cohort', function () {
             spyOn(Mozilla.Cookies, 'hasItem').and.returnValue(true);
             spyOn(Mozilla.Cookies, 'getItem').and.returnValue(
-                Mozilla.TrafficCop.noVariationCookieValue
+                window.TrafficCop.noVariationCookieValue
             );
 
             expect(
-                Mozilla.TrafficCop.chooseVariation(
+                window.TrafficCop.chooseVariation(
                     cop.id,
                     cop.variations,
                     cop.totalPercentage
                 )
-            ).toEqual(Mozilla.TrafficCop.noVariationCookieValue);
+            ).toEqual(window.TrafficCop.noVariationCookieValue);
         });
     });
 
-    describe('Mozilla.TrafficCop.generateRedirectUrl', function () {
+    describe('TrafficCop.generateRedirectUrl', function () {
         it('should generate a redirect retaining the original querystring when present', function () {
             expect(
-                Mozilla.TrafficCop.generateRedirectUrl(
+                window.TrafficCop.generateRedirectUrl(
                     'v=2',
                     'https://www.mozilla.org?foo=bar'
                 )
@@ -613,7 +609,7 @@ describe('mozilla-traffic-cop.js', function () {
 
         it('should generate a redirect retaining the original hash when present', function () {
             expect(
-                Mozilla.TrafficCop.generateRedirectUrl(
+                window.TrafficCop.generateRedirectUrl(
                     'v=2',
                     'https://www.mozilla.org#hash'
                 )
@@ -622,7 +618,7 @@ describe('mozilla-traffic-cop.js', function () {
 
         it('should generate a redirect retaining the original querystring and hash when present', function () {
             expect(
-                Mozilla.TrafficCop.generateRedirectUrl(
+                window.TrafficCop.generateRedirectUrl(
                     'v=2',
                     'https://www.mozilla.org?foo=bar#hash'
                 )
@@ -631,22 +627,20 @@ describe('mozilla-traffic-cop.js', function () {
 
         it('should not generate a redirect if no variation was chosen', function () {
             expect(
-                Mozilla.TrafficCop.generateRedirectUrl(
-                    Mozilla.TrafficCop.noVariationCookieValue
+                window.TrafficCop.generateRedirectUrl(
+                    window.TrafficCop.noVariationCookieValue
                 )
             ).toBeFalsy();
         });
     });
 
-    describe('Mozilla.TrafficCop.setReferrerCookie', function () {
+    describe('TrafficCop.setReferrerCookie', function () {
         it('should set referrer cookie to `direct` if no document.referer exists', function () {
             spyOn(Mozilla.Cookies, 'setItem').and.returnValue(true);
-            spyOn(Mozilla.TrafficCop, 'getDocumentReferrer').and.returnValue(
-                ''
-            );
-            Mozilla.TrafficCop.setReferrerCookie(new Date());
+            spyOn(window.TrafficCop, 'getDocumentReferrer').and.returnValue('');
+            window.TrafficCop.setReferrerCookie(new Date());
             expect(Mozilla.Cookies.setItem).toHaveBeenCalledWith(
-                Mozilla.TrafficCop.referrerCookieName,
+                window.TrafficCop.referrerCookieName,
                 'direct',
                 jasmine.any(Date),
                 undefined,
@@ -658,12 +652,12 @@ describe('mozilla-traffic-cop.js', function () {
 
         it('should set referrer cookie to the value of `document.referrer` if exists', function () {
             spyOn(Mozilla.Cookies, 'setItem').and.returnValue(true);
-            Mozilla.TrafficCop.setReferrerCookie(
+            window.TrafficCop.setReferrerCookie(
                 new Date(),
                 'http://www.google.com'
             );
             expect(Mozilla.Cookies.setItem).toHaveBeenCalledWith(
-                Mozilla.TrafficCop.referrerCookieName,
+                window.TrafficCop.referrerCookieName,
                 'http://www.google.com',
                 jasmine.any(Date),
                 undefined,
@@ -676,9 +670,9 @@ describe('mozilla-traffic-cop.js', function () {
         it('should set referrer cookie to the value of `document.referrer` if exists', function () {
             spyOn(Mozilla.Cookies, 'setItem').and.returnValue(true);
             // karma does seem to have a document.referer when running these tests...
-            Mozilla.TrafficCop.setReferrerCookie(new Date());
+            window.TrafficCop.setReferrerCookie(new Date());
             expect(Mozilla.Cookies.setItem).toHaveBeenCalledWith(
-                Mozilla.TrafficCop.referrerCookieName,
+                window.TrafficCop.referrerCookieName,
                 jasmine.stringMatching(/^http.*/),
                 jasmine.any(Date),
                 undefined,
@@ -689,19 +683,19 @@ describe('mozilla-traffic-cop.js', function () {
         });
     });
 
-    describe('Mozilla.TrafficCop.clearReferrerCookie', function () {
+    describe('TrafficCop.clearReferrerCookie', function () {
         it('should remove the referrer cookie', function () {
             spyOn(Mozilla.Cookies, 'removeItem').and.returnValue(true);
-            Mozilla.TrafficCop.clearReferrerCookie();
+            window.TrafficCop.clearReferrerCookie();
             expect(Mozilla.Cookies.removeItem).toHaveBeenCalledWith(
-                Mozilla.TrafficCop.referrerCookieName
+                window.TrafficCop.referrerCookieName
             );
         });
     });
 
-    describe('Mozilla.TrafficCop.getDocumentReferrer', function () {
+    describe('TrafficCop.getDocumentReferrer', function () {
         it('should return a non-zero length string for document.referrer', function () {
-            expect(Mozilla.TrafficCop.getDocumentReferrer()).toEqual(
+            expect(window.TrafficCop.getDocumentReferrer()).toEqual(
                 jasmine.stringMatching(/^http.*/)
             );
         });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,7 +10,7 @@ module.exports = {
         filename: 'index.js',
         path: path.resolve(__dirname, 'dist'),
         library: {
-            name: 'trafficcop',
+            name: 'TrafficCop',
             type: 'umd'
         }
     },


### PR DESCRIPTION
- Removes `Mozilla` JS namespace.
- Updates readme with how to use examples.
- Adds CHANGELOG.md
- Updates tests.