### PR TITLE
Add demo setup steps, fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ In the above example, a visitor would have a 25% chance of being chosen for `a`,
 
 Check out [the docs](./documentation.md) for more complete information.
 
-## Further Doumentation
+## Further Documentation
 
 -   [Building the NPM package](docs/#building-the-npm-package)
 -   [Running tests](docs/#running-tests)

--- a/demo/README.md
+++ b/demo/README.md
@@ -2,7 +2,10 @@
 
 ## Install & run
 
-1. Download this repo: `git clone https://github.com/mozilla/trafficcop.git && cd trafficcop/demo`
-2. Install the dependencies: `npm install`
-3. Start the server: `npm start`
-4. Open the demo application in a browser: `http://localhost:3030`
+1. Download this repo: `git clone https://github.com/mozilla/trafficcop.git`
+2. Move into repo folder: `cd trafficcop`
+3. Build the TrafficCop helper: `npm install && npm build`
+4. Move into the demo folder: `cd demo`
+5. Install the demo dependencies: `npm install`
+6. Start the server: `npm start`
+7. Open the demo application in a browser: `http://localhost:3030`


### PR DESCRIPTION
I ran into an issue trying to directly run the demo without having built the TrafficCop helper from the root folder first.

This is further documentation clarification for anyone else who runs into that issue.