### PR TITLE
Update Demo Readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # HEAD
 
--  **docs:** Update docs import `@mozmeao/cookie-helper`.
+-   **docs:** Update docs import `@mozmeao/cookie-helper`.
 
 # 2.0.0
 

--- a/demo/README.md
+++ b/demo/README.md
@@ -2,10 +2,10 @@
 
 ## Install & run
 
-1. Download this repo: `git clone https://github.com/mozilla/trafficcop.git`
+1. Download this repo: `git clone https://github.com/mozmeao/trafficcop.git`
 2. Move into repo folder: `cd trafficcop`
-3. Build the TrafficCop helper: `npm install && npm build`
+3. Build the TrafficCop helper: `npm install && npm run build`
 4. Move into the demo folder: `cd demo`
 5. Install the demo dependencies: `npm install`
 6. Start the server: `npm start`
-7. Open the demo application in a browser: `http://localhost:3030`
+7. Open the demo application in a browser: http://localhost:3030


### PR DESCRIPTION
Some of the commands in the demo's readme just needed a little cleanup to work correctly:
- Clone from `mozmeao/trafficcop` not `mozilla/trafficcop` 
- Updated the `build` command to be `npm run build` 
- Made the localhost URL clickable! 🦒